### PR TITLE
change the way saving task data

### DIFF
--- a/src/spiffworkflow_backend/models/active_data.py
+++ b/src/spiffworkflow_backend/models/active_data.py
@@ -1,0 +1,12 @@
+"""Active_data"""
+
+from dataclasses import dataclass
+from flask_bpmn.models.db import db
+from flask_bpmn.models.db import SpiffworkflowBaseDBModel
+
+@dataclass
+class ActiveDataModel(SpiffworkflowBaseDBModel):
+    __tablename__ = "active_data"
+
+    id = db.Column(db.Integer, primary_key=True)
+    spiffworkflow_task_data: str = db.Column(db.Text)

--- a/src/spiffworkflow_backend/models/active_task.py
+++ b/src/spiffworkflow_backend/models/active_task.py
@@ -41,3 +41,15 @@ class ActiveTaskModel(SpiffworkflowBaseDBModel):
 
     updated_at_in_seconds: int = db.Column(db.Integer)
     created_at_in_seconds: int = db.Column(db.Integer)
+
+    """
+    In case of multi-instance, perhaps more than one task may be generated.
+    After one task getting completed, the internal variable "Activity_identifier_CurrentVar" will be 
+    updated. The variable is shared for all tasks in order to satisfy the completion condition.
+    So more active_task records might be related to one active_date record.
+    if the above solution is practicable, the save of ActiveTaskModel  will be adjusted later.
+    The spiffworkflow_task_data of ActiveTaskModel will be removed either.
+    """
+    active_data_id: int = db.Column(
+        ForeignKey(ActiveDataModel.id), nullable=True
+    )


### PR DESCRIPTION
In case of multi-instance, perhaps more than one task may be generated. After one task getting completed, the internal variable "Activity_identifier_CurrentVar" will be  updated. The variable is shared for all tasks in order to satisfy the completion condition. So more active_task records might be related to one active_date record. if the above solution is practicable, the save of ActiveTaskModel  will be adjusted later. The spiffworkflow_task_data of ActiveTaskModel will be removed either.